### PR TITLE
Add Godep Command As Image Entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM golang:1.5.1
 
 RUN go get github.com/tools/godep
+ENTRYPOINT [ "godep" ]


### PR DESCRIPTION
This will set Godep as the image's main command. Now you can run your container with `docker run` as if you are running the Godep command directly. For example

``` sh
$ docker run --rm divideandconquer/docker-godep            # like godep
$ docker run --rm divideandconquer/docker-godep save       # like godep save
$ docker run --rm divideandconquer/docker-godep path       # like godep path
$ docker run --rm divideandconquer/docker-godep go build   # like godep go build
$ docker run --rm divideandconquer/docker-godep go save    # like godep go save
```
